### PR TITLE
Update README with full list of training algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ Train Large Language Models localy on Apple Silicon using MLX. Training works wi
 - MiniCPM, MiniCPM3
 - and more ...
 
+Supported training algorithms include:
+
+- LoRA, DoRA, and full-precision fine-tuning
+- Supervised Fine-Tuning (SFT)
+- Direct Preference Optimization (DPO)
+- Online Direct Preference Optimization (Online DPO)
+- eXtended Preference Optimization (XPO)
+- Contrastive Preference Optimization (CPO)
+- Odds Ratio Preference Optimization (ORPO)
+- Reinforcement Learning from Human Feedback (RLHF)
+- Group Relative Policy Optimization (GRPO)
+- Pretraining models from scratch
+
 ### 📓 Notebooks Examples
 
 * [🧪 LoRA Fine-Tuning (SFT)](examples/custom_sft_lora.ipynb) – Shows how to fine-tune a model using LoRA on a standard SFT dataset.


### PR DESCRIPTION
## Summary
- clarify supported training modes in the README so it matches `train.py`

## Testing
- `pre-commit run --files README.md` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e559159f08320b86c7e79bb1aa483