### PR TITLE
Refactor model loading and saving functions + Lm Studio exporting

### DIFF
--- a/examples/conversational_sft_detailed.ipynb
+++ b/examples/conversational_sft_detailed.ipynb
@@ -47,7 +47,7 @@
     "from mlx_lm_lora.trainer.datasets import CacheDataset, TextDataset\n",
     "\n",
     "# For loading/saving the model and calculating the steps\n",
-    "from mlx_lm_lora.utils import from_pretrained, fuse_and_save_model, calculate_iters\n",
+    "from mlx_lm_lora.utils import from_pretrained, save_pretrained_merged, calculate_iters\n",
     "\n",
     "# For loading the dataset\n",
     "from datasets import load_dataset\n",
@@ -112,33 +112,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model, tokenizer = from_pretrained(\n",
+    "model, tokenizer, adapter_file = from_pretrained(\n",
     "    model=model_name,\n",
-    "    lora_config=lora_config, # None for no LoRA\n",
-    "    quantized_load=quantized_config, # None for full bf16\n",
-    ")\n",
-    "print_trainable_parameters(model)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d113624e",
-   "metadata": {},
-   "source": [
-    "# Set the adapter path and file"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "55dc3a2f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "adapter_path = Path(adapter_path)\n",
-    "adapter_path.mkdir(parents=True, exist_ok=True)\n",
-    "adapter_file = adapter_path / \"adapters.safetensors\"\n",
-    "save_config(lora_config, adapter_path / \"adapter_config.json\")"
+    "    new_adapter_path=adapter_path,\n",
+    "    lora_config=lora_config,\n",
+    "    quantized_load=quantized_config\n",
+    ")"
    ]
   },
   {
@@ -388,7 +367,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fuse_and_save_model(\n",
+    "save_pretrained_merged(\n",
     "    model=model,\n",
     "    tokenizer=tokenizer,\n",
     "    save_path=adapter_path,\n",

--- a/examples/conversational_sft_minimal.ipynb
+++ b/examples/conversational_sft_minimal.ipynb
@@ -47,7 +47,7 @@
     "from mlx_lm_lora.trainer.datasets import CacheDataset, ChatDataset\n",
     "\n",
     "# For loading/saving the model and calculating the steps\n",
-    "from mlx_lm_lora.utils import from_pretrained, fuse_and_save_model, calculate_iters\n",
+    "from mlx_lm_lora.utils import from_pretrained, save_pretrained_merged, calculate_iters\n",
     "\n",
     "# For loading the dataset\n",
     "from datasets import load_dataset\n",
@@ -110,33 +110,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model, tokenizer = from_pretrained(\n",
+    "model, tokenizer, adapter_file = from_pretrained(\n",
     "    model=model_name,\n",
-    "    lora_config=lora_config, # None for no LoRA\n",
-    "    quantized_load=quantized_config, # None for full bf16\n",
-    ")\n",
-    "print_trainable_parameters(model)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d113624e",
-   "metadata": {},
-   "source": [
-    "# Set the adapter path and file"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "55dc3a2f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "adapter_path = Path(adapter_path)\n",
-    "adapter_path.mkdir(parents=True, exist_ok=True)\n",
-    "adapter_file = adapter_path / \"adapters.safetensors\"\n",
-    "save_config(lora_config, adapter_path / \"adapter_config.json\")"
+    "    new_adapter_path=adapter_path,\n",
+    "    lora_config=lora_config,\n",
+    "    quantized_load=quantized_config\n",
+    ")"
    ]
   },
   {
@@ -289,7 +268,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fuse_and_save_model(\n",
+    "save_pretrained_merged(\n",
     "    model=model,\n",
     "    tokenizer=tokenizer,\n",
     "    save_path=adapter_path,\n",

--- a/examples/dpo_minimal.ipynb
+++ b/examples/dpo_minimal.ipynb
@@ -39,7 +39,7 @@
     "from mlx_lm_lora.trainer.datasets import CacheDataset, PreferenceDataset\n",
     "\n",
     "# For loading/saving the model and calculating the steps\n",
-    "from mlx_lm_lora.utils import from_pretrained, fuse_and_save_model, calculate_iters\n",
+    "from mlx_lm_lora.utils import from_pretrained, save_pretrained_merged, calculate_iters\n",
     "\n",
     "# For loading the dataset\n",
     "from datasets import load_dataset\n",
@@ -95,30 +95,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ref_model, _ = from_pretrained(\n",
+    "ref_model, _, _ = from_pretrained(\n",
     "    model=ref_model_name,\n",
     "    quantized_load=None, # Ref model shoudl be \"smarter\" then studend model\n",
     ")\n",
     "\n",
-    "model, tokenizer = from_pretrained(\n",
+    "model, tokenizer, adapter_file = from_pretrained(\n",
     "    model=model_name,\n",
+    "    new_adapter_path=adapter_path,\n",
     "    lora_config=lora_config,\n",
-    "    quantized_load=quantized_config,\n",
+    "    quantized_load=quantized_config\n",
     ")\n",
     "print_trainable_parameters(model)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fb1f3902",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "adapter_path = Path(adapter_path)\n",
-    "adapter_path.mkdir(parents=True, exist_ok=True)\n",
-    "adapter_file = adapter_path / \"adapters.safetensors\"\n",
-    "save_config(lora_config, adapter_path / \"adapter_config.json\")"
    ]
   },
   {
@@ -313,7 +301,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fuse_and_save_model(\n",
+    "save_pretrained_merged(\n",
     "    model=model,\n",
     "    tokenizer=tokenizer,\n",
     "    save_path=adapter_path,\n",

--- a/examples/grpo_minimal.ipynb
+++ b/examples/grpo_minimal.ipynb
@@ -48,7 +48,7 @@
     ")\n",
     "\n",
     "# For loading/saving the model and calculating the steps\n",
-    "from mlx_lm_lora.utils import from_pretrained, fuse_and_save_model, calculate_iters\n",
+    "from mlx_lm_lora.utils import from_pretrained, save_pretrained_merged, calculate_iters\n",
     "\n",
     "# For loading the dataset\n",
     "from datasets import load_dataset\n",
@@ -104,15 +104,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ref_model, _ = from_pretrained(\n",
+    "ref_model, _, _ = from_pretrained(\n",
     "    model=ref_model_name,\n",
     "    quantized_load=None, # Ref model shoudl be \"smarter\" then studend model\n",
     ")\n",
     "\n",
-    "model, tokenizer = from_pretrained(\n",
+    "model, tokenizer, adapter_file = from_pretrained(\n",
     "    model=model_name,\n",
+    "    new_adapter_path=adapter_path,\n",
     "    lora_config=lora_config,\n",
-    "    quantized_load=quantized_config,\n",
+    "    quantized_load=quantized_config\n",
     ")\n",
     "print_trainable_parameters(model)"
    ]

--- a/examples/orpo_minimal.ipynb
+++ b/examples/orpo_minimal.ipynb
@@ -39,7 +39,7 @@
     "from mlx_lm_lora.trainer.datasets import CacheDataset, PreferenceDataset\n",
     "\n",
     "# For loading/saving the model and calculating the steps\n",
-    "from mlx_lm_lora.utils import from_pretrained, fuse_and_save_model, calculate_iters\n",
+    "from mlx_lm_lora.utils import from_pretrained, save_pretrained_merged, calculate_iters\n",
     "\n",
     "# For loading the dataset\n",
     "from datasets import load_dataset\n",
@@ -95,15 +95,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ref_model, _ = from_pretrained(\n",
+    "ref_model, _, _ = from_pretrained(\n",
     "    model=ref_model_name,\n",
     "    quantized_load=None, # Ref model shoudl be \"smarter\" then studend model\n",
     ")\n",
     "\n",
-    "model, tokenizer = from_pretrained(\n",
+    "model, tokenizer, adapter_file = from_pretrained(\n",
     "    model=model_name,\n",
+    "    new_adapter_path=adapter_path,\n",
     "    lora_config=lora_config,\n",
-    "    quantized_load=quantized_config,\n",
+    "    quantized_load=quantized_config\n",
     ")\n",
     "print_trainable_parameters(model)"
    ]
@@ -295,7 +296,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fuse_and_save_model(\n",
+    "save_pretrained_merged(\n",
     "    model=model,\n",
     "    tokenizer=tokenizer,\n",
     "    save_path=adapter_path,\n",

--- a/examples/r1_full_pipeline.ipynb
+++ b/examples/r1_full_pipeline.ipynb
@@ -49,7 +49,7 @@
     ")\n",
     "\n",
     "# For loading/saving the model and calculating the steps\n",
-    "from mlx_lm_lora.utils import from_pretrained, fuse_and_save_model, calculate_iters\n",
+    "from mlx_lm_lora.utils import from_pretrained, save_pretrained_merged, calculate_iters\n",
     "\n",
     "# For loading the dataset\n",
     "from datasets import load_dataset, Dataset\n",
@@ -120,30 +120,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "zero_ref_model, zero_ref_tokenizer = from_pretrained(\n",
+    "zero_ref_model, zero_ref_tokenizer, _ = from_pretrained(\n",
     "    model=zero_ref_model_name,\n",
     "    quantized_load=quantized_config,\n",
     ")\n",
     "\n",
-    "zero_model, zero_tokenizer = from_pretrained(\n",
-    "    model=base_model_name,\n",
+    "zero_model, zero_tokenizer, adapter_file = from_pretrained(\n",
+    "    model=r1_model_name,\n",
+    "    new_adapter_path=zero_adapter_path,\n",
     "    lora_config=lora_config,\n",
-    "    quantized_load=quantized_config,\n",
+    "    quantized_load=quantized_config\n",
     ")\n",
     "print_trainable_parameters(zero_model)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fb1f3902",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "adapter_path = Path(zero_adapter_path)\n",
-    "adapter_path.mkdir(parents=True, exist_ok=True)\n",
-    "adapter_file = adapter_path / \"adapters.safetensors\"\n",
-    "save_config(lora_config, adapter_path / \"adapter_config.json\")"
    ]
   },
   {
@@ -832,7 +820,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fuse_and_save_model(\n",
+    "save_pretrained_merged(\n",
     "    model=r1_model,\n",
     "    tokenizer=r1_tokenizer,\n",
     "    save_path=adapter_path,\n",

--- a/examples/r1_sft.ipynb
+++ b/examples/r1_sft.ipynb
@@ -47,7 +47,7 @@
     "from mlx_lm_lora.trainer.datasets import CacheDataset, TextDataset\n",
     "\n",
     "# For loading/saving the model and calculating the steps\n",
-    "from mlx_lm_lora.utils import from_pretrained, fuse_and_save_model, calculate_iters\n",
+    "from mlx_lm_lora.utils import from_pretrained, save_pretrained_merged, calculate_iters\n",
     "\n",
     "# For loading the dataset\n",
     "from datasets import load_dataset\n",
@@ -112,33 +112,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model, tokenizer = from_pretrained(\n",
+    "model, tokenizer, adapter_file = from_pretrained(\n",
     "    model=model_name,\n",
-    "    lora_config=lora_config, # None for no LoRA\n",
-    "    quantized_load=quantized_config, # None for full bf16\n",
-    ")\n",
-    "print_trainable_parameters(model)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d113624e",
-   "metadata": {},
-   "source": [
-    "# Set the adapter path and file"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "55dc3a2f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "adapter_path = Path(adapter_path)\n",
-    "adapter_path.mkdir(parents=True, exist_ok=True)\n",
-    "adapter_file = adapter_path / \"adapters.safetensors\"\n",
-    "save_config(lora_config, adapter_path / \"adapter_config.json\")"
+    "    new_adapter_path=adapter_path,\n",
+    "    lora_config=lora_config,\n",
+    "    quantized_load=quantized_config\n",
+    ")"
    ]
   },
   {
@@ -311,7 +290,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fuse_and_save_model(\n",
+    "save_pretrained_merged(\n",
     "    model=model,\n",
     "    tokenizer=tokenizer,\n",
     "    save_path=adapter_path,\n",

--- a/examples/r1_zero_cold_start.ipynb
+++ b/examples/r1_zero_cold_start.ipynb
@@ -49,7 +49,7 @@
     ")\n",
     "\n",
     "# For loading/saving the model and calculating the steps\n",
-    "from mlx_lm_lora.utils import from_pretrained, fuse_and_save_model, calculate_iters\n",
+    "from mlx_lm_lora.utils import from_pretrained, save_pretrained_merged, push_to_hub, calculate_iters\n",
     "\n",
     "# For loading the dataset\n",
     "from datasets import load_dataset\n",
@@ -82,7 +82,8 @@
    "source": [
     "model_name = \"mistralai/Ministral-3-3B-Base-2512\"\n",
     "ref_model_name = \"mistralai/Ministral-3-3B-Base-2512\"\n",
-    "adapter_path = \"./ministral-3-3b-zero\"\n",
+    "new_model_name = \"Ministral-3-3B-Zero-Coldstart\"\n",
+    "adapter_path = f\"./{new_model_name}\"\n",
     "zero_dataset_name = \"mlx-community/Dolci-Think-RL-7B-2k\"\n",
     "cold_start_dataset_name = \"icedpanda/msmarco_cold_start_dataset_5k\"\n",
     "\n",
@@ -107,25 +108,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model, tokenizer = from_pretrained(\n",
+    "model, tokenizer, adapter_file = from_pretrained(\n",
     "    model=model_name,\n",
+    "    new_adapter_path=adapter_path,\n",
     "    lora_config=lora_config,\n",
-    "    quantized_load=quantized_config,\n",
-    ")\n",
-    "print_trainable_parameters(model)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fb1f3902",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "adapter_path = Path(adapter_path)\n",
-    "adapter_path.mkdir(parents=True, exist_ok=True)\n",
-    "adapter_file = adapter_path / \"adapters.safetensors\"\n",
-    "save_config(lora_config, adapter_path / \"adapter_config.json\")"
+    "    quantized_load=quantized_config\n",
+    ")"
    ]
   },
   {
@@ -424,11 +412,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fuse_and_save_model(\n",
+    "save_pretrained_merged(\n",
     "    model=model,\n",
     "    tokenizer=tokenizer,\n",
     "    save_path=adapter_path,\n",
     "    de_quantize=True # Since we quantized the model on load\n",
+    ")\n",
+    "\n",
+    "# You can directly push the model and adapter to Hugging Face Hub with the following code. Make sure to replace \"YOUR_HF_KEY\" with your actual Hugging Face API key and set the new_model_name variable to your desired repository name.\n",
+    "push_to_hub(\n",
+    "    model_path=adapter_path,\n",
+    "    hf_repo=f\"mlx-community/{new_model_name}\",\n",
+    "    api_key=\"YOUR_HF_KEY\",\n",
+    "    private=False,\n",
+    "    commit_message=\"initial commit\",\n",
     ")"
    ]
   },

--- a/examples/r1_zero_minimal.ipynb
+++ b/examples/r1_zero_minimal.ipynb
@@ -48,7 +48,7 @@
     ")\n",
     "\n",
     "# For loading/saving the model and calculating the steps\n",
-    "from mlx_lm_lora.utils import from_pretrained, fuse_and_save_model, calculate_iters\n",
+    "from mlx_lm_lora.utils import from_pretrained, save_pretrained_merged, push_to_hub, calculate_iters\n",
     "\n",
     "# For loading the dataset\n",
     "from datasets import load_dataset\n",
@@ -81,7 +81,8 @@
    "source": [
     "model_name = \"mistralai/Ministral-3-3B-Base-2512\"\n",
     "ref_model_name = \"mistralai/Ministral-3-3B-Base-2512\"\n",
-    "adapter_path = \"./Ministral-3-3B-Zero\"\n",
+    "new_model_name = \"Ministral-3-3B-Zero\"\n",
+    "adapter_path = f\"./{new_model_name}\"\n",
     "dataset_name = \"mlx-community/Dolci-Think-RL-7B-2k\"\n",
     "\n",
     "max_seq_length = 4096\n",
@@ -105,30 +106,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ref_model, _ = from_pretrained(\n",
+    "ref_model, _, _ = from_pretrained(\n",
     "    model=ref_model_name,\n",
     "    quantized_load=quantized_config, # Ref model shoudl be \"smarter\" then studend model\n",
     ")\n",
     "\n",
-    "model, tokenizer = from_pretrained(\n",
+    "model, tokenizer, adapter_file = from_pretrained(\n",
     "    model=model_name,\n",
+    "    new_adapter_path=adapter_path,\n",
     "    lora_config=lora_config,\n",
-    "    quantized_load=quantized_config,\n",
+    "    quantized_load=quantized_config\n",
     ")\n",
     "print_trainable_parameters(model)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fb1f3902",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "adapter_path = Path(adapter_path)\n",
-    "adapter_path.mkdir(parents=True, exist_ok=True)\n",
-    "adapter_file = adapter_path / \"adapters.safetensors\"\n",
-    "save_config(lora_config, adapter_path / \"adapter_config.json\")"
    ]
   },
   {
@@ -379,11 +368,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fuse_and_save_model(\n",
+    "save_pretrained_merged(\n",
     "    model=model,\n",
     "    tokenizer=tokenizer,\n",
     "    save_path=adapter_path,\n",
     "    de_quantize=True # Since we quantized the model on load\n",
+    ")\n",
+    "\n",
+    "push_to_hub(\n",
+    "    model_path=adapter_path,\n",
+    "    hf_repo=f\"mlx-community/{new_model_name}\",\n",
+    "    api_key=\"YOUR_HF_KEY\",\n",
+    "    private=False,\n",
+    "    commit_message=\"initial commit\",\n",
     ")"
    ]
   },

--- a/examples/sft_lmstudio.ipynb
+++ b/examples/sft_lmstudio.ipynb
@@ -47,7 +47,7 @@
     "from mlx_lm_lora.trainer.datasets import CacheDataset, ChatDataset\n",
     "\n",
     "# For loading/saving the model and calculating the steps\n",
-    "from mlx_lm_lora.utils import from_pretrained, fuse_and_save_model, calculate_iters, send_to_lmstudio\n",
+    "from mlx_lm_lora.utils import from_pretrained, save_to_lmstudio_merged, calculate_iters\n",
     "\n",
     "# For loading the dataset\n",
     "from datasets import load_dataset\n",
@@ -111,33 +111,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model, tokenizer = from_pretrained(\n",
+    "model, tokenizer, adapter_file = from_pretrained(\n",
     "    model=model_name,\n",
-    "    lora_config=lora_config, # None for no LoRA\n",
-    "    quantized_load=quantized_config, # None for full bf16\n",
-    ")\n",
-    "print_trainable_parameters(model)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d113624e",
-   "metadata": {},
-   "source": [
-    "# Set the adapter path and file"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "55dc3a2f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "adapter_path = Path(adapter_path)\n",
-    "adapter_path.mkdir(parents=True, exist_ok=True)\n",
-    "adapter_file = adapter_path / \"adapters.safetensors\"\n",
-    "save_config(lora_config, adapter_path / \"adapter_config.json\")"
+    "    new_adapter_path=adapter_path,\n",
+    "    lora_config=lora_config,\n",
+    "    quantized_load=quantized_config\n",
+    ")"
    ]
   },
   {
@@ -292,7 +271,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "send_to_lmstudio(\n",
+    "save_to_lmstudio_merged(\n",
     "    model=model,\n",
     "    tokenizer=tokenizer,\n",
     "    new_model_name=new_model_name,\n",
@@ -312,17 +291,11 @@
     "Cheers,\n",
     "Gökdeniz"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ce6209c2",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "itsm",
+   "display_name": "mlx-lm-lora-dev",
    "language": "python",
    "name": "python3"
   },
@@ -336,7 +309,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/mlx_lm_lora/utils.py
+++ b/mlx_lm_lora/utils.py
@@ -32,10 +32,8 @@ def find_lmstudio_models_path() -> Path:
     lm = Path.home() / ".lmstudio" / "models"
 
     if not lm.exists():
-        raise FileNotFoundError(
-            f"LM Studio models root not found at {lm}"
-        )
-    
+        raise FileNotFoundError(f"LM Studio models root not found at {lm}")
+
     return lm
 
 
@@ -137,7 +135,13 @@ def save_pretrained_merged(
         args.pop("quantization", None)
         args.pop("quantization_config", None)
 
-    save_pretrained(model=model, tokenizer=tokenizer, save_path=save_path, export_gguf=export_gguf, gguf_path=gguf_path)
+    save_pretrained(
+        model=model,
+        tokenizer=tokenizer,
+        save_path=save_path,
+        export_gguf=export_gguf,
+        gguf_path=gguf_path,
+    )
 
 
 def from_pretrained(
@@ -198,9 +202,16 @@ def from_pretrained(
                 "mode": mode,
             }
             model.args.quantization_config = model.args.quantization
-    
+
     if new_adapter_path is not None:
-        args = {"lora_parameters": lora_config, "num_layers": lora_config.get("num_layers", None)} if lora_config is not None else {} | args
+        args = (
+            {
+                "lora_parameters": lora_config,
+                "num_layers": lora_config.get("num_layers", None),
+            }
+            if lora_config is not None
+            else {} | args
+        )
         new_adapter_path = Path(new_adapter_path)
         new_adapter_path.mkdir(parents=True, exist_ok=True)
         new_adapter_file = new_adapter_path / "adapters.safetensors"
@@ -254,7 +265,12 @@ def push_to_hub(
 
     # Upload the model files
     api.upload_folder(
-        folder_path=model_path, repo_id=hf_repo, commit_message=commit_message, ignore_patterns=["adapters*.safetensors", "adapters*.json"] if remove_adapters else None
+        folder_path=model_path,
+        repo_id=hf_repo,
+        commit_message=commit_message,
+        ignore_patterns=(
+            ["adapters*.safetensors", "adapters*.json"] if remove_adapters else None
+        ),
     )
 
     print(f"✅ Model successfully pushed to https://huggingface.co/{hf_repo}")

--- a/mlx_lm_lora/utils.py
+++ b/mlx_lm_lora/utils.py
@@ -22,7 +22,78 @@ def calculate_iters(train_set, batch_size, epochs) -> int:
     return iters
 
 
-def fuse_and_save_model(
+def find_lmstudio_models_path() -> Path:
+    """
+    Find the LM Studio models directory.
+
+    Returns:
+        Path: The path to the LM Studio models directory.
+    """
+    lm = Path.home() / ".lmstudio" / "models"
+
+    if not lm.exists():
+        raise FileNotFoundError(
+            f"LM Studio models root not found at {lm}"
+        )
+    
+    return lm
+
+
+def save_pretrained(
+    model: nn.Module,
+    tokenizer: TokenizerWrapper,
+    save_path: str = "fused_model",
+    export_gguf: Optional[bool] = False,
+    gguf_path: Optional[str] = "ggml-model-f16.gguf",
+) -> None:
+    """
+    Fuse fine-tuned adapters into the base model.
+
+    Args:
+        model: The MLX model to fuse adapters into.
+        tokenizer: The tokenizer wrapper.
+        save_path: The path to save the fused model.
+        export_gguf: Export model weights in GGUF format.
+        gguf_path: Path to save the exported GGUF format model weights.
+    """
+    from ._version import __version__
+
+    save_path_obj = Path(save_path)
+    save_model(save_path_obj, model, donate_model=True)
+    save_config(vars(model.args), config_path=save_path_obj / "config.json")
+    tokenizer.save_pretrained(save_path_obj)
+
+    readme_content = f"""# MLX-LM-LoRA Model
+
+This model was fine-tuned using [mlx-lm-lora](https://github.com/Goekdeniz-Guelmez/mlx-lm-lora) version {__version__}.
+
+## Model Details
+
+- Base model: {model.args.get('model_name', 'Unknown')}
+- Model type: {model.args.get('model_type', 'Unknown')}
+- Training method: LoRA fine-tuning with MLX
+- Fusion date: {datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
+
+## Usage
+
+This model can be loaded and used with the MLX framework.
+"""
+    with open(save_path_obj / "README.md", "w") as f:
+        f.write(readme_content)
+
+    print(f"Created README.md in {save_path}")
+
+    if export_gguf:
+        model_type = model.args["model_type"]
+        if model_type not in ["llama", "mixtral", "mistral"]:
+            raise ValueError(
+                f"Model type {model_type} not supported for GGUF conversion."
+            )
+        weights = dict(tree_flatten(model.parameters()))
+        convert_to_gguf(save_path, weights, model.args, str(save_path_obj / gguf_path))
+
+
+def save_pretrained_merged(
     model: nn.Module,
     tokenizer: TokenizerWrapper,
     save_path: str = "fused_model",
@@ -66,45 +137,13 @@ def fuse_and_save_model(
         args.pop("quantization", None)
         args.pop("quantization_config", None)
 
-    save_path_obj = Path(save_path)
-    save_model(save_path_obj, model, donate_model=True)
-    save_config(args, config_path=save_path_obj / "config.json")
-    tokenizer.save_pretrained(save_path_obj)
-
-    readme_content = f"""# MLX-LM-LoRA Model
-
-This model was fine-tuned using [mlx-lm-lora](https://github.com/Goekdeniz-Guelmez/mlx-lm-lora) version {__version__}.
-
-## Model Details
-
-- Base model: {args.get('model_name', 'Unknown')}
-- Model type: {args.get('model_type', 'Unknown')}
-- Training method: LoRA fine-tuning with MLX
-- Fusion date: {datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
-
-## Usage
-
-This model can be loaded and used with the MLX framework.
-"""
-
-    with open(save_path_obj / "README.md", "w") as f:
-        f.write(readme_content)
-
-    print(f"Created README.md in {save_path}")
-
-    if export_gguf:
-        model_type = args["model_type"]
-        if model_type not in ["llama", "mixtral", "mistral"]:
-            raise ValueError(
-                f"Model type {model_type} not supported for GGUF conversion."
-            )
-        weights = dict(tree_flatten(model.parameters()))
-        convert_to_gguf(save_path, weights, args, str(save_path_obj / gguf_path))
+    save_pretrained(model=model, tokenizer=tokenizer, save_path=save_path, export_gguf=export_gguf, gguf_path=gguf_path)
 
 
 def from_pretrained(
     model: str,
     adapter_path: Optional[str] = None,
+    new_adapter_path: Optional[str] = None,
     lora_config: Optional[dict] = None,
     quantized_load: Optional[dict] = None,
 ) -> Tuple[nn.Module, Any]:
@@ -115,7 +154,7 @@ def from_pretrained(
         lora_config: Configuration for LoRA adapters.
         quantized_load: If provided, the model will be loaded with quantization.
     Returns:
-        Tuple[nn.Module, tokenizer]: The model with LoRA adapters loaded, and tokenizer.
+        Tuple[nn.Module, tokenizer, Optional[str]]: The model with LoRA adapters loaded, the tokenizer, and the adapter path if provided.
     """
     print(f"Loading model {model}")
     model, tokenizer = load(model, adapter_path=adapter_path)
@@ -147,7 +186,7 @@ def from_pretrained(
             raise ValueError("Cannot quantize already quantized model")
 
         bits = quantized_load.get("bits", 4)
-        group_size = quantized_load.get("group_size", 128)
+        group_size = quantized_load.get("group_size", 64)
         mode = quantized_load.get("mode", "affine")
 
         nn.quantize(model, bits=bits, group_size=group_size, mode=mode)
@@ -159,16 +198,24 @@ def from_pretrained(
                 "mode": mode,
             }
             model.args.quantization_config = model.args.quantization
+    
+    if new_adapter_path is not None:
+        args = {"lora_parameters": lora_config, "num_layers": lora_config.get("num_layers", None)} if lora_config is not None else {} | args
+        new_adapter_path = Path(new_adapter_path)
+        new_adapter_path.mkdir(parents=True, exist_ok=True)
+        new_adapter_file = new_adapter_path / "adapters.safetensors"
+        save_config(args, new_adapter_path / "adapter_config.json")
 
-    return model, tokenizer
+    return model, tokenizer, new_adapter_file if new_adapter_path is not None else None
 
 
-def push_to_hf(
+def push_to_hub(
     model_path: str,
     hf_repo: str,
     api_key: str,
     private: bool = False,
     commit_message: Optional[str] = None,
+    remove_adapters: Optional[bool] = False,
 ) -> None:
     """
     Push the fused model to the Hugging Face Hub.
@@ -179,6 +226,7 @@ def push_to_hf(
         api_key: Hugging Face API token.
         private: Whether to create a private repository.
         commit_message: Custom commit message for the upload.
+        remove_adapters: Whether to remove adapters before pushing.
     """
     try:
         from huggingface_hub import HfApi, create_repo
@@ -196,7 +244,7 @@ def push_to_hf(
 
     # Create the repo if it doesn't exist
     try:
-        create_repo(hf_repo, private=private, token=api_key)
+        create_repo(hf_repo, private=private, token=api_key, repo_type="model")
     except Exception as e:
         print(f"Repository creation failed or repository already exists: {e}")
 
@@ -206,13 +254,13 @@ def push_to_hf(
 
     # Upload the model files
     api.upload_folder(
-        folder_path=model_path, repo_id=hf_repo, commit_message=commit_message
+        folder_path=model_path, repo_id=hf_repo, commit_message=commit_message, ignore_patterns=["adapters*.safetensors", "adapters*.json"] if remove_adapters else None
     )
 
     print(f"✅ Model successfully pushed to https://huggingface.co/{hf_repo}")
 
 
-def send_to_lmstudio(
+def save_to_lmstudio_merged(
     model: nn.Module,
     tokenizer: TokenizerWrapper,
     new_model_name: str = "mlx_lm_lora_model",
@@ -228,12 +276,7 @@ def send_to_lmstudio(
         de_quantize: Generate a de-quantized model.
     """
 
-    lmstudio_models_root = Path.home() / ".lmstudio" / "models"
-
-    if not lmstudio_models_root.exists():
-        raise FileNotFoundError(
-            f"LM Studio models root not found at {lmstudio_models_root}"
-        )
+    lmstudio_models_root = find_lmstudio_models_path()
 
     lmstudio_models_path = lmstudio_models_root / "mlx_lm_lora"
     lmstudio_models_path.mkdir(parents=True, exist_ok=True)
@@ -242,7 +285,7 @@ def send_to_lmstudio(
 
     print(f"LM Studio models directory found at: {lmstudio_models_root}")
 
-    fuse_and_save_model(
+    save_pretrained_merged(
         model=model,
         tokenizer=tokenizer,
         save_path=str(model_path),


### PR DESCRIPTION
…ew methods

- Replaced `fuse_and_save_model` with `save_pretrained_merged` in multiple example notebooks.
- Updated `from_pretrained` function to return adapter file path and accept new adapter path.
- Added `find_lmstudio_models_path` function to locate LM Studio models directory.
- Modified `send_to_lmstudio` to `save_to_lmstudio_merged` for consistency.
- Adjusted example notebooks to reflect changes in model loading and saving processes.