### PR TITLE
Fix ORPO gradient computation: forward pass outside differentiated cl…

### DIFF
--- a/mlx_lm_lora/trainer/orpo_trainer.py
+++ b/mlx_lm_lora/trainer/orpo_trainer.py
@@ -260,14 +260,16 @@ def train_orpo(
     state = [model.state, optimizer.state, mx.random.state]
 
     def loss_wrapper(
-        chosen_logps,
-        chosen_logits_mean,
-        rejected_logps,
-        rejected_logits_mean,
+        chosen,
+        rejected,
         chosen_masks,
         rejected_masks,
         preference_scores,
     ):
+        chosen_logps, chosen_logits_mean = get_logps(model, chosen, chosen_masks)
+        rejected_logps, rejected_logits_mean = get_logps(
+            model, rejected, rejected_masks
+        )
         return loss(
             chosen_logps=chosen_logps,
             chosen_logits_mean=chosen_logits_mean,
@@ -285,18 +287,8 @@ def train_orpo(
     def step(batch, prev_grad, do_update):
         chosen, rejected, chosen_masks, rejected_masks, preference_scores = batch
 
-        chosen_logps, chosen_logits_mean = get_logps(model, chosen, chosen_masks)
-        rejected_logps, rejected_logits_mean = get_logps(
-            model, rejected, rejected_masks
-        )
-
         (lvalue, reward, toks, metrics), grad = loss_value_and_grad(
-            chosen_logps,
-            chosen_logits_mean,
-            rejected_logps,
-            rejected_logits_mean,
-            chosen_masks,
-            rejected_masks,
+            chosen, rejected, chosen_masks, rejected_masks,
             preference_scores=preference_scores,
         )
 


### PR DESCRIPTION
…osure

Root cause

In mlx_lm_lora/trainer/orpo_trainer.py, the model's forward pass (get_logps) was being called outside loss_wrapper, the function that nn.value_and_grad(model, loss_wrapper) actually differentiates. loss_wrapper only received the already-computed numeric log-probabilities as plain arguments -- it never called model itself. Since the differentiated function had no computational dependency on model's parameters, the gradient computed was exactly zero for every parameter, every step -- mathematically correct given what was actually being differentiated, just not what was intended.

Contrast with dpo_trainer.py's train_dpo(), where get_token_scores(model, ...) is called INSIDE loss_wrapper -- the forward pass sits inside the traced closure there, so gradients correctly flow back to the model. This is why DPO trains correctly under otherwise identical conditions while ORPO did not.

Observed symptom

Training with --train-mode orpo, resumed from a converged SFT adapter via --resume-adapter-file, ran to completion over 1,000 iterations reporting plausible, varying metrics throughout (loss, chosen_r, rejected_r, margin, accuracy). But the saved adapter -- checked via SHA-256 at multiple checkpoints including iterations 100, 500, and 1000 -- was byte-for-byte identical to the resumed starting adapter every time. No parameter update was ever persisted, consistent with a structurally-zero gradient.

Fix (verified working)

Moved the get_logps(model, ...) calls inside loss_wrapper, mirroring how dpo_trainer.py calls get_token_scores inside its own loss_wrapper. loss_wrapper now takes the raw chosen/rejected token tensors and masks directly, computes the forward pass internally, and step() passes those raw tensors straight into loss_value_and_grad instead of pre-computed log-probs.

Applied this patch locally and re-ran the exact reproduction above (resume from the same SFT adapter, --train-mode orpo, 10-20 iterations). Before the patch: saved adapter byte-identical to the resumed starting checkpoint at every iteration tested. After the patch: the checkpoint at iteration 10 already differs (confirmed via SHA-256), with accuracy climbing from 0.5 -> 1.0 and margin moving from ~0.01 to ~0.10-0.15 over the first 20 iterations -- real, working preference learning.

Reproduction

mlx_lm_lora.train -c orpo_config.yaml --train --train-mode orpo \
  --data ./build/orpo --model Qwen/Qwen3-8B --adapter-path ./adapters/v4 \
  --resume-adapter-file ./adapters/v4-sft/adapters.safetensors

shasum -a 256 ./adapters/v4/adapters.safetensors ./adapters/v4-sft/adapters.safetensors # -> identical at every checkpoint before this fix; differ after it

Environment: mlx-lm-lora 3.0.0, mlx 0.32.0, mlx-lm 0.31.3, macOS 26.5.2, Qwen/Qwen3-8B, LoRA rank 16.