### PR TITLE
fix(cpo): move the model forward pass inside the differentiated function

### DIFF
--- a/mlx_lm_lora/trainer/cpo_trainer.py
+++ b/mlx_lm_lora/trainer/cpo_trainer.py
@@ -77,6 +77,35 @@ def cpo_loss(
     return mx.mean(losses), reward, num_tokens, metrics
 
 
+def cpo_loss_from_model(
+    model,
+    chosen,
+    rejected,
+    chosen_masks,
+    rejected_masks,
+    beta: float,
+    delta: float,
+    loss=cpo_loss,
+    loss_type: str = "sigmoid",
+):
+    """Compute CPO loss with model forwards in the differentiated function."""
+    policy_chosen_scores = get_token_scores(model, chosen, chosen_masks)
+    policy_rejected_scores = get_token_scores(model, rejected, rejected_masks)
+    policy_chosen_score = compute_score(policy_chosen_scores, chosen_masks, loss_type)
+    policy_rejected_score = compute_score(
+        policy_rejected_scores, rejected_masks, loss_type
+    )
+    return loss(
+        policy_chosen_score=policy_chosen_score,
+        policy_rejected_score=policy_rejected_score,
+        chosen_masks=chosen_masks,
+        rejected_masks=rejected_masks,
+        beta=beta,
+        delta=delta,
+        loss_type=loss_type,
+    )
+
+
 def iterate_cpo_batches(dataset, batch_size, max_seq_length, train=False):
     idx = sorted(range(len(dataset)), key=lambda idx: len(dataset[idx]["chosen"]))
 
@@ -241,19 +270,10 @@ def train_cpo(
     def step(batch, prev_grad, do_update):
         chosen, rejected, chosen_masks, rejected_masks = batch
 
-        policy_chosen_scores = get_token_scores(model, chosen, chosen_masks)
-        policy_rejected_scores = get_token_scores(model, rejected, rejected_masks)
-
-        policy_chosen_score = compute_score(
-            policy_chosen_scores, chosen_masks, args.loss_type
-        )
-        policy_rejected_score = compute_score(
-            policy_rejected_scores, rejected_masks, args.loss_type
-        )
-
         (lvalue, reward, toks, metrics), grad = loss_value_and_grad(
-            policy_chosen_score,
-            policy_rejected_score,
+            model,
+            chosen,
+            rejected,
             chosen_masks=chosen_masks,
             rejected_masks=rejected_masks,
         )
@@ -270,14 +290,14 @@ def train_cpo(
 
         return lvalue, reward, toks, metrics, grad
 
-    def loss_wrapper(
-        policy_chosen_score, policy_rejected_score, chosen_masks, rejected_masks
-    ):
-        return loss_fn(
-            policy_chosen_score=policy_chosen_score,
-            policy_rejected_score=policy_rejected_score,
-            chosen_masks=chosen_masks,
-            rejected_masks=rejected_masks,
+    def loss_wrapper(model, chosen, rejected, chosen_masks, rejected_masks):
+        return cpo_loss_from_model(
+            model,
+            chosen,
+            rejected,
+            chosen_masks,
+            rejected_masks,
+            loss=loss_fn,
             beta=args.beta,
             delta=args.delta,
             loss_type=args.loss_type,


### PR DESCRIPTION
The CPO trainer's default `step()` path computes a gradient that is identically zero with respect
to the model, so `--train-mode cpo` runs to completion and trains nothing.

`nn.value_and_grad(model, loss_wrapper)` differentiates `loss_wrapper`, but the wrapper only ever
received already-materialised scores — every forward pass through `model` happened *before*
`nn.value_and_grad` was invoked, so the differentiated function had no dependence on the model
parameters.

Shaped after your `orpo_loss_from_model` in #66: a `cpo_loss_from_model(model, chosen, rejected, ...)`
doing the forwards inside the differentiated function, with `loss_wrapper` re-signatured to take the
model and raw tokens.

`seq_split_step()` is untouched — it was already correct, which is both why this hid and how it can
be checked. `seq_step_size` is only non-None under `--efficient-long-context` (`train.py:725` for
CPO), and that flag is documented "Experimental" — so CPO trained correctly only under an
experimental flag and silently didn't on the default documented path.

### Verification — measured on `main`, four runs

Same resume source, same data, same config (`--train-mode cpo --train-type lora --num-layers 8
--batch-size 1 --learning-rate 1e-5`), only the code path differs:

| adapter written | sha256 (first 20) |
|---|---|
| resume source | `db0d7c8362e7391558d0` |
| `main` unpatched, default path | `db0d7c8362e7391558d0` — **identical to source** |
| `main` patched, default path | `3ea309b99aa1bf1a469f` |
| `main` patched, `--efficient-long-context` | `3ea309b99aa1bf1a469f` |

- Unpatched default: **0 / 112 tensors moved, max abs delta exactly 0.000e+00.**
- Patched default: **112 / 112 moved, max abs delta 7.418e-05**, 0 NaN/Inf.
- The patched default path now produces byte-identical weights to the already-correct chunked path
  — i.e. the fix makes the broken path compute exactly what `seq_split_step` was already computing,
  checked against your own code as the oracle. (It also shows training is deterministic at these
  settings, which is what makes that comparison meaningful.)

CPO is reference-free, so there is no KL term to produce drift — the movement is the policy
gradient, which previously never reached the weights.

### Tests

`python -m unittest discover -s tests` — 82 / 82 pass on `main` with this patch applied. The patch
doesn't touch `cpo_loss` itself, only how it is reached.

### What this does not claim

Three iterations demonstrate that gradients reach the weights. They say nothing about whether CPO
**converges well**, which is a separate question.

Refs #65.
