### PR TITLE
docs: fix custom reward function example (raises TypeError as written)

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,13 +376,26 @@ Create a Python file with reward functions:
 
 ```python
 # my_rewards.py
-from mlx_lm_lora.reward_functions import register_reward_function
+from typing import Optional
+
+from mlx_lm_lora.trainer.grpo_reward_functions import register_reward_function
+
 
 @register_reward_function()
-def my_custom_reward(prompt, completion, reference_answer, **kwargs):
-    """Custom reward function"""
-    # Your logic here
-    return score  # float between 0 and 1
+def my_custom_reward(
+    prompts: list, completions: list, answer: list, types: Optional[list] = None
+) -> list[float]:
+    """Score a whole batch of completions.
+
+    Reward functions are called with keyword arguments
+    (`prompts=`, `completions=`, `answer=`, `types=`), so these parameter names
+    must match exactly -- note that `answer` is singular. Each call receives the
+    full batch and must return one float per entry in `completions`.
+    """
+    return [
+        1.0 if str(a).strip() and str(a).strip() in c else 0.0
+        for c, a in zip(completions, answer)
+    ]
 ```
 
 Then use: `--reward-functions-file ./my_rewards.py --reward-functions "my_custom_reward"`

--- a/mlx_lm_lora/trainer/grpo_reward_functions.py
+++ b/mlx_lm_lora/trainer/grpo_reward_functions.py
@@ -22,7 +22,7 @@ def register_reward_function(name: str = None):
 
     Example:
         @register_reward_function()
-        def my_custom_reward(prompts, completions, answers, types=None):
+        def my_custom_reward(prompts, completions, answer, types=None):
             # Your reward logic here
             return [1.0 if condition else 0.0 for _ in completions]
     """

--- a/tests/test_reward_functions.py
+++ b/tests/test_reward_functions.py
@@ -23,11 +23,30 @@ class RewardRegistryTest(unittest.TestCase):
         name = "test_custom_reward"
 
         @rewards.register_reward_function(name)
-        def custom(prompts, completions, answers, types=None):
+        def custom(prompts, completions, answer, types=None):
             return [1.0] * len(completions)
 
         self.assertIs(rewards.get_reward_function(name), custom)
         rewards.REWARD_REGISTRY.pop(name)
+
+    def test_registered_rewards_accept_the_trainer_keyword_contract(self):
+        """calculate_rewards_and_advantages passes every argument by keyword.
+
+        A reward function whose third parameter is named anything other than
+        `answer` therefore raises TypeError on the first training step rather
+        than at registration, which is a long way from where the mistake was
+        made. Pin the call shape here so a rename cannot pass the suite.
+        """
+        batch = {
+            "prompts": ["<answer>1</answer>"],
+            "completions": ["<reasoning>r</reasoning>\n<answer>1</answer>\n"],
+            "answer": ["1"],
+            "types": [None],
+        }
+        for name in rewards.list_available_reward_functions():
+            with self.subTest(reward=name):
+                scores = rewards.get_reward_function(name)(**batch)
+                self.assertEqual(len(scores), len(batch["completions"]))
 
     def test_default_rewards_are_in_expected_order(self):
         self.assertEqual(


### PR DESCRIPTION
The custom reward example at [README.md#L377-L386](https://github.com/Goekdeniz-Guelmez/mlx-lm-lora/blob/dfaaaed530d122cd03156f7e43d1f876d2af3dbc/README.md#L377-L386) raises `TypeError` on the first GRPO step. [`calculate_rewards_and_advantages`](https://github.com/Goekdeniz-Guelmez/mlx-lm-lora/blob/dfaaaed530d122cd03156f7e43d1f876d2af3dbc/mlx_lm_lora/trainer/grpo_trainer.py#L253-L258) calls rewards by keyword, so parameter names matter:

| Documented | Actual |
|---|---|
| `mlx_lm_lora.reward_functions` | `mlx_lm_lora.trainer.grpo_reward_functions` (documented module doesn't exist) |
| `prompt, completion` | `prompts, completions` (batched) |
| `reference_answer` | `answer` |
| `return score  # float` | `list[float]`, one per completion |

Corrected example matches the built-ins, e.g. [`r1_accuracy_reward_func`](https://github.com/Goekdeniz-Guelmez/mlx-lm-lora/blob/dfaaaed530d122cd03156f7e43d1f876d2af3dbc/mlx_lm_lora/trainer/grpo_reward_functions.py#L99-L101).

Second commit: [`test_custom_name_registration`](https://github.com/Goekdeniz-Guelmez/mlx-lm-lora/blob/dfaaaed530d122cd03156f7e43d1f876d2af3dbc/tests/test_reward_functions.py#L26) declared `answers` too, but never failed because it only asserts `assertIs` without calling the function. Renamed, plus a test that calls every registered reward the way the trainer does, so a rename fails in CI instead of on a user's first run.

Verified: the new README block returns `[1.0, 0.0]` when called with the trainer's signature; registering `answers` and calling with `answer=` still raises `TypeError`; 17 tests pass. No library code changed.