### PR TITLE
fix: preserve long-context chunk boundaries

### DIFF
--- a/mlx_lm_lora/trainer/cpo_trainer.py
+++ b/mlx_lm_lora/trainer/cpo_trainer.py
@@ -14,6 +14,7 @@ from tqdm import tqdm
 
 from ..recurrent_patch import enable_memory_safe_recurrences, model_uses_recurrence
 from .dpo_trainer import DPOTrainingArgs as CPOTrainingArgs
+from .long_context import iter_cached_sft_chunks
 from .sft_trainer import grad_checkpoint, reset_prompt_cache
 
 
@@ -318,14 +319,9 @@ def train_cpo(
             if curr_cache is not None:
                 reset_prompt_cache(curr_cache)
 
-            step_size = seq_step_size
-            for s in range(0, seq_length, step_size):
-                end = min(s + step_size, seq_length)
-                if 0 < (seq_length - end) < 2:
-                    end = seq_length
-
-                chunk = tokens[:, s:end]
-                chunk_mask = masks[:, s:end]
+            for start, end in iter_cached_sft_chunks(seq_length, seq_step_size):
+                chunk = tokens[:, start:end]
+                chunk_mask = masks[:, start:end]
 
                 chunk_scores = get_token_scores(
                     curr_model, chunk, chunk_mask, cache=curr_cache
@@ -391,14 +387,9 @@ def train_cpo(
             seq_length = tokens.shape[1]
             reset_prompt_cache(cache)
 
-            step_size = seq_step_size
-            for s in range(0, seq_length, step_size):
-                end = min(s + step_size, seq_length)
-                if 0 < (seq_length - end) < 2:
-                    end = seq_length
-
-                chunk = tokens[:, s:end]
-                chunk_mask = masks[:, s:end]
+            for start, end in iter_cached_sft_chunks(seq_length, seq_step_size):
+                chunk = tokens[:, start:end]
+                chunk_mask = masks[:, start:end]
 
                 def local_loss_fn(model):
                     local_sum = get_token_scores(

--- a/mlx_lm_lora/trainer/dpo_trainer.py
+++ b/mlx_lm_lora/trainer/dpo_trainer.py
@@ -14,6 +14,7 @@ from mlx_lm.tuner.callbacks import TrainingCallback
 from tqdm import tqdm
 
 from ..recurrent_patch import enable_memory_safe_recurrences, model_uses_recurrence
+from .long_context import iter_cached_sft_chunks
 from .sft_trainer import (
     SFTTrainingArgs,
     _install_qat_hooks,
@@ -369,14 +370,9 @@ def train_dpo(
             if curr_cache is not None:
                 reset_prompt_cache(curr_cache)
 
-            step_size = seq_step_size
-            for s in range(0, seq_length, step_size):
-                end = min(s + step_size, seq_length)
-                if 0 < (seq_length - end) < 2:
-                    end = seq_length
-
-                chunk = tokens[:, s:end]
-                chunk_mask = masks[:, s:end]
+            for start, end in iter_cached_sft_chunks(seq_length, seq_step_size):
+                chunk = tokens[:, start:end]
+                chunk_mask = masks[:, start:end]
 
                 chunk_scores = get_token_scores(
                     curr_model, chunk, chunk_mask, cache=curr_cache
@@ -461,14 +457,9 @@ def train_dpo(
             seq_length = tokens.shape[1]
             reset_prompt_cache(cache)
 
-            step_size = seq_step_size
-            for s in range(0, seq_length, step_size):
-                end = min(s + step_size, seq_length)
-                if 0 < (seq_length - end) < 2:
-                    end = seq_length
-
-                chunk = tokens[:, s:end]
-                chunk_mask = masks[:, s:end]
+            for start, end in iter_cached_sft_chunks(seq_length, seq_step_size):
+                chunk = tokens[:, start:end]
+                chunk_mask = masks[:, start:end]
 
                 def local_loss_fn(model):
                     local_sum = get_token_scores(

--- a/mlx_lm_lora/trainer/long_context.py
+++ b/mlx_lm_lora/trainer/long_context.py
@@ -1,0 +1,18 @@
+"""Shared helpers for cached long-context training."""
+
+
+def iter_cached_sft_chunks(seq_length: int, seq_step_size: int):
+    """Yield cached next-token-loss bounds with one token of left context.
+
+    A loss over ``batch[:, start:end]`` predicts targets in
+    ``[start + 1, end)``.  Continuation chunks therefore include the previous
+    target token as context, making every next-token target appear exactly
+    once while preserving the cached autoregressive state.
+    """
+    for chunk_start in range(0, seq_length, seq_step_size):
+        end = min(chunk_start + seq_step_size, seq_length)
+        if 0 < (seq_length - end) < 2:
+            end = seq_length
+        yield max(0, chunk_start - 1), end
+        if end >= seq_length:
+            break

--- a/mlx_lm_lora/trainer/orpo_trainer.py
+++ b/mlx_lm_lora/trainer/orpo_trainer.py
@@ -14,6 +14,7 @@ from mlx_lm.tuner.callbacks import TrainingCallback
 from tqdm import tqdm
 
 from ..recurrent_patch import enable_memory_safe_recurrences, model_uses_recurrence
+from .long_context import iter_cached_sft_chunks
 from .sft_trainer import (
     SFTTrainingArgs,
     _install_qat_hooks,
@@ -377,13 +378,9 @@ def train_orpo(
 
             reset_prompt_cache(cache)
 
-            for s in range(0, seq_length, seq_step_size):
-                end = min(s + seq_step_size, seq_length)
-                if 0 < (seq_length - end) < 2:
-                    end = seq_length
-
-                chunk = tokens[:, s:end]
-                chunk_mask = masks[:, s:end]
+            for start, end in iter_cached_sft_chunks(seq_length, seq_step_size):
+                chunk = tokens[:, start:end]
+                chunk_mask = masks[:, start:end]
 
                 chunk_avg, chunk_logits_mean = get_logps(
                     model, chunk, chunk_mask, cache
@@ -461,13 +458,9 @@ def train_orpo(
 
             chunk_value_and_grad = nn.value_and_grad(model, chunk_loss_fn)
 
-            for s in range(0, seq_length, seq_step_size):
-                end = min(s + seq_step_size, seq_length)
-                if 0 < (seq_length - end) < 2:
-                    end = seq_length
-
-                chunk = tokens[:, s:end]
-                chunk_mask = masks[:, s:end]
+            for start, end in iter_cached_sft_chunks(seq_length, seq_step_size):
+                chunk = tokens[:, start:end]
+                chunk_mask = masks[:, start:end]
 
                 _, grad = chunk_value_and_grad(chunk, chunk_mask, weights)
 

--- a/mlx_lm_lora/trainer/sft_trainer.py
+++ b/mlx_lm_lora/trainer/sft_trainer.py
@@ -21,6 +21,7 @@ from tqdm import tqdm
 
 from ..recurrent_patch import enable_memory_safe_recurrences, model_uses_recurrence
 from .datasets import CacheDataset
+from .long_context import iter_cached_sft_chunks
 
 _CHUNKED_NLL_CHUNK_SIZE = 256
 
@@ -404,12 +405,8 @@ def evaluate_sft(
     ):
         if efficient and cache is not None:
             seq_length = batch[0].shape[1]
-            for s in range(0, seq_length, seq_step_size):
-                end = min(s + seq_step_size, seq_length)
-                # If next chunk would have only 1 token, absorb it into this chunk
-                if 0 < (seq_length - end) < 2:
-                    end = seq_length
-                local_batch = (batch[0][:, s:end], batch[1])
+            for start, end in iter_cached_sft_chunks(seq_length, seq_step_size):
+                local_batch = (batch[0][:, start:end], batch[1])
                 losses, toks = loss(model, *local_batch, cache)
                 all_losses += losses * toks
                 ntokens += toks
@@ -499,21 +496,23 @@ def train_sft(
         seq_length = batch[0].shape[1]
         seq_grad_accum = None
 
-        for s in range(0, seq_length, seq_step_size):
-            end = min(s + seq_step_size, seq_length)
-            # If next chunk would have only 1 token, absorb it into this chunk
-            if 0 < (seq_length - end) < 2:
-                end = seq_length
-            local_batch = (batch[0][:, s:end], batch[1])
+        for start, end in iter_cached_sft_chunks(seq_length, seq_step_size):
+            local_batch = (batch[0][:, start:end], batch[1])
             (lvalue, toks), grad = loss_value_and_grad(model, *local_batch, cache)
+            prev_n_tokens = n_tokens
             losses += toks * lvalue
             n_tokens += toks
 
-            # Simple gradient summation (no weighted averaging)
             if seq_grad_accum is None:
                 seq_grad_accum = grad
             else:
-                seq_grad_accum = tree_map(lambda g, acc: g + acc, grad, seq_grad_accum)
+                scale_grad = toks / n_tokens
+                scale_accum = prev_n_tokens / n_tokens
+                seq_grad_accum = tree_map(
+                    lambda g, acc: scale_grad * g + scale_accum * acc,
+                    grad,
+                    seq_grad_accum,
+                )
 
             # Reset prompt cache before the last eval
             if end >= seq_length:
@@ -526,8 +525,7 @@ def train_sft(
 
         lvalue = losses / n_tokens
         toks = n_tokens
-        num_chunks = (seq_length + seq_step_size - 1) // seq_step_size
-        grad = tree_map(lambda g: g / num_chunks, seq_grad_accum)
+        grad = seq_grad_accum
 
         # Handle gradient accumulation across steps
         if prev_grad is not None:

--- a/tests/test_training_algorithms.py
+++ b/tests/test_training_algorithms.py
@@ -15,6 +15,7 @@ from mlx_lm_lora.trainer import (
     sft_trainer,
     xpo_trainer,
 )
+from mlx_lm_lora.trainer.long_context import iter_cached_sft_chunks
 
 
 def _scalar(value):
@@ -88,6 +89,18 @@ class SFTTrainerTest(unittest.TestCase):
 
         self.assertEqual(sft_trainer._find_cache_offset([None, [Cache()]]), 7)
         self.assertIsNone(sft_trainer._find_cache_offset(None))
+
+    def test_sequence_chunks_preserve_every_next_token_target(self):
+        bounds = list(iter_cached_sft_chunks(2049, 512))
+        self.assertEqual(
+            bounds,
+            [(0, 512), (511, 1024), (1023, 1536), (1535, 2049)],
+        )
+
+        predicted_targets = [
+            target for start, end in bounds for target in range(start + 1, end)
+        ]
+        self.assertEqual(predicted_targets, list(range(1, 2049)))
 
     def test_reset_prompt_cache_calls_reset_protocol(self):
         class Cache:


### PR DESCRIPTION
## Summary
- centralize cached long-context chunking for SFT, DPO, CPO, and ORPO
- preserve one left-context token between chunks so every next-token target is scored exactly once
- restore valid-token-weighted SFT gradient aggregation across chunks
- add a 2049-token regression test for 512-token chunks

Fixes #84.