### PR TITLE
fix: update ORPODataset to track prompt lengths and adjust masks in t…

### DIFF
--- a/mlx_lm_lora/trainer/datasets.py
+++ b/mlx_lm_lora/trainer/datasets.py
@@ -274,6 +274,8 @@ class ORPODataset:
     ):
         self._chosen_data = []
         self._rejected_data = []
+        self._chosen_prompt_lengths = []
+        self._rejected_prompt_lengths = []
         self._scores = []
 
         for d in data:
@@ -328,6 +330,7 @@ class ORPODataset:
                 rejected_text = tokenizer.apply_chat_template(
                     rejected_messages, add_generation_prompt=False
                 )
+                prompt_messages = base_messages
 
             else:
                 chosen_content = self._extract_content(d[chosen_key])
@@ -345,9 +348,17 @@ class ORPODataset:
                         {"role": "assistant", "content": rejected_content},
                     ]
                 )
+                prompt_messages = [{"role": "user", "content": prompt_content}]
 
             self._chosen_data.append(chosen_text)
             self._rejected_data.append(rejected_text)
+            prompt_length = len(
+                tokenizer.apply_chat_template(
+                    prompt_messages, add_generation_prompt=True
+                )
+            )
+            self._chosen_prompt_lengths.append(prompt_length)
+            self._rejected_prompt_lengths.append(prompt_length)
 
             if preference_score_key in d:
                 self._scores.append(float(d[preference_score_key]))
@@ -383,6 +394,8 @@ class ORPODataset:
         return {
             "chosen": self._chosen_data[idx],
             "rejected": self._rejected_data[idx],
+            "chosen_prompt_length": self._chosen_prompt_lengths[idx],
+            "rejected_prompt_length": self._rejected_prompt_lengths[idx],
             "preference_score": self._scores[idx],
         }
 

--- a/mlx_lm_lora/trainer/orpo_trainer.py
+++ b/mlx_lm_lora/trainer/orpo_trainer.py
@@ -42,7 +42,9 @@ def get_logps(model, tokens, mask, cache=None):
     log_probs = -nn.losses.cross_entropy(logits, targets, reduction="none")
     log_probs = mx.clip(log_probs, -1000.0, 0.0)
 
-    mask = mask[:, :-1]
+    # Each log-probability predicts tokens[:, 1:], so align the token mask
+    # with those targets rather than with the input positions.
+    mask = mask[:, 1:]
     seq_lengths = mask.sum(-1)
     logp_sum = (log_probs * mask).sum(-1)
     safe_seq_lengths = mx.where(seq_lengths > 0, seq_lengths, 1.0)
@@ -91,7 +93,7 @@ def orpo_loss(
     rejected_reward = beta * rejected_logps
     reward = mx.stack([mx.mean(chosen_reward), mx.mean(rejected_reward)])
 
-    num_tokens = chosen_masks.sum() + rejected_masks.sum()
+    num_tokens = chosen_masks[:, 1:].sum() + rejected_masks[:, 1:].sum()
 
     metrics = {
         "accuracies": mx.mean((chosen_reward > rejected_reward).astype(mx.float32)),
@@ -188,11 +190,17 @@ def iterate_orpo_batches(dataset, batch_size, max_seq_length, train=False):
                 rejected_length = min(rejected_lengths[j], max_length_in_batch)
 
                 chosen_arr[j, :chosen_length] = batch[j]["chosen"][:chosen_length]
-                chosen_masks[j, :chosen_length] = 1.0
+                chosen_prompt_length = min(
+                    batch[j].get("chosen_prompt_length", 0), chosen_length
+                )
+                chosen_masks[j, chosen_prompt_length:chosen_length] = 1.0
                 rejected_arr[j, :rejected_length] = batch[j]["rejected"][
                     :rejected_length
                 ]
-                rejected_masks[j, :rejected_length] = 1.0
+                rejected_prompt_length = min(
+                    batch[j].get("rejected_prompt_length", 0), rejected_length
+                )
+                rejected_masks[j, rejected_prompt_length:rejected_length] = 1.0
 
             yield (
                 mx.array(chosen_arr),
@@ -386,7 +394,7 @@ def train_orpo(
                     model, chunk, chunk_mask, cache
                 )
 
-                chunk_input_mask = chunk_mask[:, :-1]
+                chunk_input_mask = chunk_mask[:, 1:]
                 chunk_lens = chunk_input_mask.sum(-1)
 
                 logp_sum += chunk_avg * chunk_lens
@@ -406,8 +414,8 @@ def train_orpo(
         c_logp_sum, c_logits_mean = compute_logps_chunked(chosen, chosen_masks)
         r_logp_sum, r_logits_mean = compute_logps_chunked(rejected, rejected_masks)
 
-        c_lens = chosen_masks[:, :-1].sum(-1)
-        r_lens = rejected_masks[:, :-1].sum(-1)
+        c_lens = chosen_masks[:, 1:].sum(-1)
+        r_lens = rejected_masks[:, 1:].sum(-1)
         c_lens_safe = mx.where(c_lens > 0, c_lens, 1.0)
         r_lens_safe = mx.where(r_lens > 0, r_lens, 1.0)
 
@@ -452,7 +460,7 @@ def train_orpo(
 
             def chunk_loss_fn(chunk, chunk_mask, weights):
                 chunk_avg, _ = get_logps(model, chunk, chunk_mask, cache)
-                chunk_lens = chunk_mask[:, :-1].sum(-1)
+                chunk_lens = chunk_mask[:, 1:].sum(-1)
                 chunk_sum = chunk_avg * chunk_lens
                 return (chunk_sum * weights).sum()
 

--- a/tests/test_training_algorithms.py
+++ b/tests/test_training_algorithms.py
@@ -234,7 +234,7 @@ class OnlineDPOTrainerTest(unittest.TestCase):
         )
         self.assertTrue(mx.isfinite(loss).item())
         self.assertEqual(reward.shape, (2,))
-        self.assertEqual(_scalar(tokens), 6.0)
+        self.assertEqual(_scalar(tokens), 10.0)
         self.assertGreaterEqual(_scalar(metrics["accuracies"]), 0.0)
 
     def test_online_dpo_rejects_unknown_loss(self):
@@ -270,7 +270,7 @@ class ORPOTrainerTest(unittest.TestCase):
         )
         self.assertTrue(mx.isfinite(loss).item())
         self.assertTrue(mx.all(mx.isfinite(reward)).item())
-        self.assertEqual(_scalar(tokens), 10.0)
+        self.assertEqual(_scalar(tokens), 6.0)
         self.assertIn("rejected_logits_mean", metrics)
 
     def test_orpo_loss_matches_sft_plus_odds_ratio_objective(self):

--- a/tests/test_training_algorithms.py
+++ b/tests/test_training_algorithms.py
@@ -234,7 +234,7 @@ class OnlineDPOTrainerTest(unittest.TestCase):
         )
         self.assertTrue(mx.isfinite(loss).item())
         self.assertEqual(reward.shape, (2,))
-        self.assertEqual(_scalar(tokens), 10.0)
+        self.assertEqual(_scalar(tokens), 6.0)
         self.assertGreaterEqual(_scalar(metrics["accuracies"]), 0.0)
 
     def test_online_dpo_rejects_unknown_loss(self):
@@ -329,6 +329,37 @@ class ORPOTrainerTest(unittest.TestCase):
         batch = next(orpo_trainer.iterate_orpo_batches(data, 2, 8))
         self.assertEqual(batch[0].shape, (2, 8))
         self.assertTrue(mx.allclose(batch[4], mx.array([0.75, 0.25])).item())
+
+    def test_orpo_batch_iterator_masks_only_response_targets(self):
+        data = [
+            {
+                "chosen": [1, 2, 3],
+                "rejected": [1, 2, 4, 5],
+                "chosen_prompt_length": 2,
+                "rejected_prompt_length": 2,
+            },
+            {
+                "chosen": [6, 7, 8, 9],
+                "rejected": [6, 7, 10],
+                "chosen_prompt_length": 1,
+                "rejected_prompt_length": 1,
+            },
+        ]
+        _, _, chosen_masks, rejected_masks, _ = next(
+            orpo_trainer.iterate_orpo_batches(data, 2, 8)
+        )
+        self.assertTrue(
+            mx.array_equal(
+                chosen_masks,
+                mx.array([[0, 0, 1, 0, 0, 0, 0, 0], [0, 1, 1, 1, 0, 0, 0, 0]]),
+            ).item()
+        )
+        self.assertTrue(
+            mx.array_equal(
+                rejected_masks,
+                mx.array([[0, 0, 1, 1, 0, 0, 0, 0], [0, 1, 1, 0, 0, 0, 0, 0]]),
+            ).item()
+        )
 
 
 class PPOTrainerTest(unittest.TestCase):


### PR DESCRIPTION
Fixes #79 by ensuring ORPO scores only assistant-response tokens, rather than the system and user prompt.

- Track prompt lengths in `ORPODataset`
- Build chosen/rejected masks only from the response boundary through the unpadded sequence
- Align masks with next-token targets using `mask[:, 1:]`
- Correct ORPO token accounting to use the aligned target masks
- Add regression coverage for response-only ORPO batch masks