### PR TITLE
Fix lazy validation aggregate evaluation

### DIFF
--- a/mlx_lm_lora/trainer/cpo_trainer.py
+++ b/mlx_lm_lora/trainer/cpo_trainer.py
@@ -225,7 +225,7 @@ def evaluate_cpo(
             for k, v in metrics.items():
                 all_metrics[k] += v * toks
 
-        mx.eval(all_losses, all_rewards, ntokens)
+        mx.eval(all_losses, all_rewards, ntokens, *all_metrics.values())
     all_losses = mx.distributed.all_sum(all_losses)
     all_rewards = mx.distributed.all_sum(all_rewards)
     ntokens = mx.distributed.all_sum(ntokens)

--- a/mlx_lm_lora/trainer/dpo_trainer.py
+++ b/mlx_lm_lora/trainer/dpo_trainer.py
@@ -247,7 +247,7 @@ def evaluate_dpo(
             for k, v in metrics.items():
                 all_metrics[k] += v * toks
 
-        mx.eval(all_losses, all_rewards, ntokens)
+        mx.eval(all_losses, all_rewards, ntokens, *all_metrics.values())
     all_losses = mx.distributed.all_sum(all_losses)
     all_rewards = mx.distributed.all_sum(all_rewards)
     ntokens = mx.distributed.all_sum(ntokens)

--- a/mlx_lm_lora/trainer/ftpo_trainer.py
+++ b/mlx_lm_lora/trainer/ftpo_trainer.py
@@ -174,10 +174,10 @@ def evaluate_ftpo(
             if totals is None
             else {k: totals[k] + v for k, v in metrics.items()}
         )
+        mx.eval(total_loss, *totals.values())
         count += 1
     if count == 0:
         raise ValueError("No FTPO evaluation batches available")
-    mx.eval(total_loss, *totals.values())
     return total_loss.item() / count, {k: v / count for k, v in totals.items()}
 
 

--- a/mlx_lm_lora/trainer/grpo_trainer.py
+++ b/mlx_lm_lora/trainer/grpo_trainer.py
@@ -745,7 +745,7 @@ def evaluate_grpo(
             for k, v in metrics.items():
                 all_metrics[k] += v * toks
 
-    mx.eval(all_losses, ntokens)
+        mx.eval(all_losses, ntokens, *all_metrics.values())
 
     all_losses = mx.distributed.all_sum(all_losses, stream=mx.cpu)
     ntokens = mx.distributed.all_sum(ntokens, stream=mx.cpu)

--- a/mlx_lm_lora/trainer/online_dpo_trainer.py
+++ b/mlx_lm_lora/trainer/online_dpo_trainer.py
@@ -349,7 +349,7 @@ def evaluate_online_dpo(
             for k, v in metrics.items():
                 all_metrics[k] += v * toks
 
-    mx.eval(all_losses, all_rewards, ntokens)
+        mx.eval(all_losses, all_rewards, ntokens, *all_metrics.values())
 
     # Distributed reduction
     all_losses = mx.distributed.all_sum(all_losses)

--- a/mlx_lm_lora/trainer/orpo_trainer.py
+++ b/mlx_lm_lora/trainer/orpo_trainer.py
@@ -251,7 +251,7 @@ def evaluate_orpo(
             for k, v in metrics.items():
                 all_metrics[k] += v * toks
 
-    mx.eval(all_losses, all_rewards, ntokens)
+        mx.eval(all_losses, all_rewards, ntokens, *all_metrics.values())
     all_losses = mx.distributed.all_sum(all_losses)
     all_rewards = mx.distributed.all_sum(all_rewards)
     ntokens = mx.distributed.all_sum(ntokens)

--- a/mlx_lm_lora/trainer/ppo_trainer.py
+++ b/mlx_lm_lora/trainer/ppo_trainer.py
@@ -271,7 +271,7 @@ def evaluate_ppo(
             for k, v in metrics.items():
                 all_metrics[k] += v * toks
 
-    mx.eval(all_losses, all_rewards, ntokens)
+        mx.eval(all_losses, all_rewards, ntokens, *all_metrics.values())
 
     # Distributed reduction
     all_losses = mx.distributed.all_sum(all_losses)

--- a/mlx_lm_lora/trainer/rlhf_reinforce_trainer.py
+++ b/mlx_lm_lora/trainer/rlhf_reinforce_trainer.py
@@ -204,7 +204,7 @@ def evaluate_rlhf_reinforce(
             for k, v in metrics.items():
                 all_metrics[k] += v * toks
 
-    mx.eval(all_losses, ntokens)
+        mx.eval(all_losses, ntokens, *all_metrics.values())
 
     # Distributed reduction
     all_losses = mx.distributed.all_sum(all_losses)

--- a/mlx_lm_lora/trainer/xpo_trainer.py
+++ b/mlx_lm_lora/trainer/xpo_trainer.py
@@ -317,7 +317,7 @@ def evaluate_xpo(
             for k, v in metrics.items():
                 all_metrics[k] += v * toks
 
-    mx.eval(all_losses, all_rewards, ntokens)
+        mx.eval(all_losses, all_rewards, ntokens, *all_metrics.values())
 
     # Distributed reduction
     all_losses = mx.distributed.all_sum(all_losses)


### PR DESCRIPTION
## Summary
- materialize validation loss, reward, token, and metric aggregates after each batch
- apply the fix across DPO, CPO, ORPO, XPO, Online DPO, PPO, RLHF-REINFORCE, GRPO, and FTPO
- preserve the existing evaluation results and distributed reductions

Closes #81