### PR TITLE
fix(orpo): make the ORPO test-set evaluation runnable

### DIFF
--- a/mlx_lm_lora/train.py
+++ b/mlx_lm_lora/train.py
@@ -830,8 +830,6 @@ def evaluate_model(
     print_section(f"Evaluating {args.train_mode.upper()} Model")
 
     if args.train_mode == "orpo":
-        efficient = args.seq_step_size is not None
-        seq_step_size = args.seq_step_size or args.max_seq_length
         test_loss, test_rewards, _, test_metrics = evaluate_orpo(
             model=model,
             dataset=test_set,
@@ -839,8 +837,6 @@ def evaluate_model(
             num_batches=args.test_batches,
             max_seq_length=args.max_seq_length,
             beta=args.beta,
-            efficient=efficient,
-            seq_step_size=seq_step_size,
         )
         test_ppl = math.exp(test_loss)
         print(


### PR DESCRIPTION
## Problem

`evaluate_model()` cannot run for `--train-mode orpo`. The ORPO branch fails twice
before it evaluates anything ([`mlx_lm_lora/train.py#L832-L844`](https://github.com/Goekdeniz-Guelmez/mlx-lm-lora/blob/main/mlx_lm_lora/train.py#L832-L844)):

```python
if args.train_mode == "orpo":
    efficient = args.seq_step_size is not None          # 1. AttributeError
    seq_step_size = args.seq_step_size or args.max_seq_length
    test_loss, test_rewards, _, test_metrics = evaluate_orpo(
        ...
        efficient=efficient,                            # 2. TypeError
        seq_step_size=seq_step_size,
    )
```

**1. `args.seq_step_size` does not exist.** `args` here is the parsed CLI/config
namespace. There is no `--seq-step-size` flag and no `seq_step_size` key in
`CONFIG_DEFAULTS`; the knob users actually have is `--efficient-long-context`,
which the training paths translate into `seq_step_size=512 if args.efficient_long_context else None`
when they build the `*TrainingArgs` dataclass (lines 578, 638, 726, 802). Only
those dataclasses carry a `seq_step_size` attribute — the CLI namespace never does.

**2. `evaluate_orpo()` takes neither keyword.** Its signature is
`evaluate_orpo(model, dataset, batch_size, num_batches, beta, max_seq_length=2048)`.

The ORPO branch is the only one of the six branches in `evaluate_model()` that does
this; `dpo`, `cpo`, `ftpo`, `online_dpo` and `ppo` all call their `evaluate_*` helper
without it.

## Fix

Delete the two dead locals and the two unsupported keywords. This makes the call
identical to the only other `evaluate_orpo()` call site, the in-training validation
pass at `trainer/orpo_trainer.py:540`, which already omits them. No behavior is lost:
`evaluate_orpo` has no chunked/long-context path to opt into.

## Verification

No GPU/Apple silicon here, so I verified by extracting the real definitions from the
repo and replaying the call bindings rather than by importing `mlx`:

- Collected every attribute the `args` namespace can carry (all `CONFIG_DEFAULTS`
  keys + every `add_argument` dest, via AST): **64 config keys, 62 CLI dests**.
  `efficient_long_context` is present; **`seq_step_size` is absent** — confirming (1).
- Rebuilt a signature-only stub of `evaluate_orpo` from its AST and bound all three
  call shapes:

```text
evaluate_orpo signature: (model, dataset, batch_size, num_batches, beta: float, max_seq_length=2048)
  orpo_trainer.py:540 (internal)     -> binds OK
  train.py:835 (as written)          -> TypeError: got an unexpected keyword argument 'efficient'
  train.py:835 (after patch)         -> binds OK
```

Diff is `+0 / -4`, deletions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
